### PR TITLE
chore: promote jx-py-test4 to version 0.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx-py-test4/jx-py-test4-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/jx-py-test4/jx-py-test4-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-23T16:25:20Z"
+  creationTimestamp: "2020-12-23T18:05:33Z"
   deletionTimestamp: null
-  name: 'jx-py-test4-0.0.1'
+  name: 'jx-py-test4-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: 94aac348744c53e958e1215d8eb6b053300e1302
+        chore: release 0.0.2
+      sha: ef0e72cfca9f5caa54b4cc9d9f75c7c0d90e4be5
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: e7e40544724309a3da12856c825c1f8e091ea7f8
+      sha: 5e25d5681247ceb21b9fc637182ec8381b3533b5
     - author:
         email: harrold.lechuga@asia.ing.com
         name: Harrold Lechuga
@@ -38,12 +38,12 @@ spec:
         email: harrold.lechuga@asia.ing.com
         name: Harrold Lechuga
       message: |
-        chore: Jenkins X build pack
-      sha: cf3bc9ff398f7a66c15b33e0424ac231e989ac65
+        update v2
+      sha: 0d7ee693f019ae06b25959ae8c8bec145e531e4b
   gitHttpUrl: https://github.com/hlechuga/jx-py-test4
   gitOwner: hlechuga
   gitRepository: jx-py-test4
   name: 'jx-py-test4'
-  releaseNotesURL: https://github.com/hlechuga/jx-py-test4/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/hlechuga/jx-py-test4/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/jx-py-test4/jx-py-test4-jx-py-test4-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx-py-test4/jx-py-test4-jx-py-test4-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-py-test4-jx-py-test4
   labels:
     draft: draft-app
-    chart: "jx-py-test4-0.0.1"
+    chart: "jx-py-test4-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx-py-test4-jx-py-test4
       containers:
         - name: jx-py-test4
-          image: "10.107.229.210/hlechuga/jx-py-test4:0.0.1"
+          image: "10.107.229.210/hlechuga/jx-py-test4:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/jx-py-test4/jx-py-test4-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx-py-test4/jx-py-test4-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx-py-test4
   labels:
-    chart: "jx-py-test4-0.0.1"
+    chart: "jx-py-test4-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/jx-py-test4
-  version: 0.0.1
+  version: 0.0.2
   name: jx-py-test4
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx-py-test4 to version 0.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge